### PR TITLE
pass an option to signal the source of the save

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -142,7 +142,7 @@ class Builder
             'accessibleFields' => ['*' => true],
         ]);
 
-        $model->save($entity);
+        $model->save($entity, ['tableFactory' => true]);
 
         return $entity;
     }


### PR DESCRIPTION
this would allow model callbacks to know when data was being created by a test factory and to respond differently

this would be helpful because in the beforeSave() logic for certain table classes, we would like to skip some logic if it's happening during the setup of test data.